### PR TITLE
U/aren55555/add state to open parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tryfinch/react-connect",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-replace": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Finch SDK for embedding Finch Connect in API React Single Page Applications (SPA)",
   "keywords": [
     "finch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export type ConnectOptions = {
   zIndex: number;
 };
 
-type OpenFn = (overrides?: Partial<Pick<ConnectOptions, 'products'>>) => void;
+type OpenFn = (overrides?: Partial<Pick<ConnectOptions, 'products' | 'state'>>) => void;
 
 const POST_MESSAGE_NAME = 'finch-auth-message' as const;
 


### PR DESCRIPTION
In addition to setting the `state` parameter when initializing the SDK, we should support setting it during the modal's open invocation. A developer may not have obtained a `state` at the time the SDK is initialized. This change allows them to defer passing a value for `state` until they actually trigger the `open` of the Finch Connect modal.

We also support the same sort of thing for dynamically sending us the list of `products`.