### PR TITLE
feat: Add provider ID to open overrides & warn on multiple useFinchConnect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tryfinch/react-connect",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-replace": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tryfinch/react-connect",
-      "version": "3.1.2",
+      "version": "3.2.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-replace": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "Finch SDK for embedding Finch Connect in API React Single Page Applications (SPA)",
   "keywords": [
     "finch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Finch SDK for embedding Finch Connect in API React Single Page Applications (SPA)",
   "keywords": [
     "finch",


### PR DESCRIPTION
### WHAT
- Add `payrollProvider` to open function overrides
- console.error on multiple invocations of the `useFinchConnect` hook. Did not make this an explicit error so as not to cause a regression in codebases that already register the `useFinchConnect` hook more than once
![Screenshot 2023-08-22 at 1 20 18 PM](https://github.com/Finch-API/react-connect/assets/23018297/9ec9c6a5-be14-4da9-aa6a-ede6bc7a75d4)


### WHY
To address [this ticket](https://tryfinch.atlassian.net/browse/EN-3364) where the event callbacks (`onSuccess`, `onError` etc) are called more than once. 

The `payrollProvider` option override is also added to the `open` function to support the use case of having more than 1 provider button. i.e.

```jsx
const { open } = useFinchConnect({
  onSuccess,
  ...
});

<GustoButton openConnect={() => open({ payrollProvider: 'gusto' })} />
<PaylocityButton openConnect={() => open({ payrollProvider: 'paylocity' })} />
...
```