### PR TITLE
feat: Sandbox provider flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tryfinch/react-connect",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-replace": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Finch SDK for embedding Finch Connect in API React Single Page Applications (SPA)",
   "keywords": [
     "finch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,13 @@ export type ConnectOptions = {
   onClose: () => void;
   payrollProvider: string | null;
   products: string[];
-  sandbox: boolean;
+  sandbox:
+    | 'provider' /** This is to enable the new Provider Sandbox */
+    /**
+     * The old sandbox flag retained for backwards compatibility.
+     * It's defaults to the Provider Sandbox
+     */
+    | boolean;
   zIndex: number;
 };
 


### PR DESCRIPTION
### What
- Add `provider` option to `sandbox` init property

### Why
- To support provider initing the provider sandbox from the React SDK

### Relevant docs
- [Jira](https://tryfinch.atlassian.net/browse/EN-4403)
- [ERD](https://www.notion.so/tryfinch/ERD-Provider-Sandbox-212b65ea8c3c49c583de2280594ad9dc?pvs=4)