### PR TITLE
fix: Only check once if hook has been registered

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tryfinch/react-connect",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-replace": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Finch SDK for embedding Finch Connect in API React Single Page Applications (SPA)",
   "keywords": [
     "finch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export type SuccessEvent = {
   code: string;
@@ -107,14 +107,21 @@ let isUseFinchConnectInitialized = false;
 
 export const useFinchConnect = (options: Partial<ConnectOptions>): { open: OpenFn } => {
   if (!options.clientId) throw new Error('must specify clientId in options for useFinchConnect');
+  const isHookMounted = useRef(false);
 
-  if (isUseFinchConnectInitialized) {
-    console.error(
-      'One useFinchConnect hook has already been registered. Please ensure to only call useFinchConnect once to avoid your event callbacks getting called more than once. You can pass in override options to the open function if you so require.'
-    );
-  } else {
-    isUseFinchConnectInitialized = true;
-  }
+  useEffect(() => {
+    if (!isHookMounted.current) {
+      if (isUseFinchConnectInitialized) {
+        console.error(
+          'One useFinchConnect hook has already been registered. Please ensure to only call useFinchConnect once to avoid your event callbacks getting called more than once. You can pass in override options to the open function if you so require.'
+        );
+      } else {
+        isUseFinchConnectInitialized = true;
+      }
+
+      isHookMounted.current = true;
+    }
+  }, []);
 
   const combinedOptions: ConnectOptions = {
     clientId: '',


### PR DESCRIPTION
### What
_title_

### Why
This is to prevent an error where the `hook already registered` error shows up when the component rerenders even if only one hook is being used