### PR TITLE
feat: Add SDK host URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tryfinch/react-connect",
-      "version": "3.3.1",
+      "version": "3.4.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-replace": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Finch SDK for embedding Finch Connect in API React Single Page Applications (SPA)",
   "keywords": [
     "finch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ interface FinchConnectPostMessage {
 
 const BASE_FINCH_CONNECT_URI = 'https://connect.tryfinch.com';
 const DEFAULT_FINCH_REDIRECT_URI = 'https://tryfinch.com';
+const SDK_HOST_URL = document.referrer;
 const FINCH_CONNECT_IFRAME_ID = 'finch-connect-iframe';
 const FINCH_AUTH_MESSAGE_NAME = 'finch-auth-message';
 
@@ -76,6 +77,8 @@ const constructAuthUrl = ({
   authUrl.searchParams.append('products', (products ?? []).join(' '));
   authUrl.searchParams.append('app_type', 'spa');
   authUrl.searchParams.append('redirect_uri', DEFAULT_FINCH_REDIRECT_URI);
+  /** The host URL of the SDK. This is used to store the referrer for postMessage purposes */
+  authUrl.searchParams.append('sdk_host_url', SDK_HOST_URL);
   authUrl.searchParams.append('mode', 'employer');
   if (manual) authUrl.searchParams.append('manual', String(manual));
   if (sandbox) authUrl.searchParams.append('sandbox', String(sandbox));


### PR DESCRIPTION
## What
This change adds the SDK host URL to the Finch Connect query parameters

## Why
This is to ensure we keep track of the document referrer and that doesn't get lost when the iFramed Connect the SDK opens reloads or redirects