### PR TITLE
Add the ability to run against local dev connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Finch SDK for embedding Finch Connect in API React Single Page Applications (SPA)",
   "keywords": [
     "finch",


### PR DESCRIPTION
Added a flag to finch connect called `finchDevMode`. If this is set to `true` and `window.location.host === 'localhost'`, we will use the dev finch connect url

Hoping this change will make it easier to test sandbox connect flows in local dev without having to symlink


Tested this out in finch playground