### PR TITLE
Add comments on sandbox param

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ const App = () => {
     products: ['company', 'directory'],
     // Check Finch's [documentation](https://developer.tryfinch.com/docs/reference/96f5be9e0ec1a-providers) for the full list of payroll provider IDs
     // payrollProvider: '<payroll-provider-id>',
-    // sandbox: false, // Omit or use 'false' if in production. Use "finch" or "provider" for sandbox testing, depending on test plan. See Finch's [documentation](https://developer.tryfinch.com/implementation-guide/Test/Testing-Plan) for an overview of Finch and Provider sandboxes.
+    // For `sandbox`, omit or use 'false' if in production. Use "finch" or "provider" for sandbox testing, depending on test plan. See Finch's [documentation](https://developer.tryfinch.com/implementation-guide/Test/Testing-Plan) for an overview of Finch and Provider sandboxes.
+    // sandbox: false,
     // manual: false,
     // zIndex: 999,
     onSuccess,

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const App = () => {
     products: ['company', 'directory'],
     // Check Finch's [documentation](https://developer.tryfinch.com/docs/reference/96f5be9e0ec1a-providers) for the full list of payroll provider IDs
     // payrollProvider: '<payroll-provider-id>',
-    // sandbox: false,
+    // sandbox: false, // Omit or use 'false' if in production. Use "finch" or "provider" for sandbox testing, depending on test plan. See Finch's [documentation](https://developer.tryfinch.com/implementation-guide/Test/Testing-Plan) for an overview of Finch and Provider sandboxes.
     // manual: false,
     // zIndex: 999,
     onSuccess,

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -16,6 +16,7 @@ const App = () => {
   const { open } = useFinchConnect({
     clientId: '<your-client-id>',
     products: ['company', 'directory', 'individual', 'employment'],
+    // For 'sandbox`, omit or use 'false' if in production. Use "finch" or "provider" for sandbox testing, depending on test plan. See Finch's [documentation](https://developer.tryfinch.com/implementation-guide/Test/Testing-Plan) for an overview of Finch and Provider sandboxes.
     // sandbox: false,
     // payrollProvider: '<payroll-provider-id>',
     onSuccess,


### PR DESCRIPTION
Adds comments above the `sandbox` parameter for `useFinchConnect()` noting that strings can be used for sandbox testing.