### PR TITLE
feat: Introduce clientName override SDK option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tryfinch/react-connect",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-replace": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Finch SDK for embedding Finch Connect in API React Single Page Applications (SPA)",
   "keywords": [
     "finch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export type ConnectOptions = {
   onClose: () => void;
   payrollProvider: string | null;
   products: string[];
+  clientName?: string;
   sandbox: Sandbox;
   zIndex: number;
   apiConfig?: {
@@ -33,7 +34,7 @@ export type ConnectOptions = {
 };
 
 type OpenFn = (
-  overrides?: Partial<Pick<ConnectOptions, 'products' | 'state' | 'payrollProvider'>>
+  overrides?: Partial<Pick<ConnectOptions, 'products' | 'state' | 'payrollProvider' | 'clientName'>>
 ) => void;
 
 const POST_MESSAGE_NAME = 'finch-auth-message' as const;
@@ -72,6 +73,7 @@ const constructAuthUrl = ({
   manual,
   sandbox,
   state,
+  clientName,
   apiConfig,
 }: Partial<ConnectOptions>) => {
   const CONNECT_URL = apiConfig?.connectUrl || BASE_FINCH_CONNECT_URI;
@@ -81,6 +83,7 @@ const constructAuthUrl = ({
   if (clientId) authUrl.searchParams.append('client_id', clientId);
   if (payrollProvider) authUrl.searchParams.append('payroll_provider', payrollProvider);
   if (category) authUrl.searchParams.append('category', category);
+  if (clientName) authUrl.searchParams.append('client_name', clientName);
   authUrl.searchParams.append('products', (products ?? []).join(' '));
   authUrl.searchParams.append('app_type', 'spa');
   authUrl.searchParams.append('redirect_uri', REDIRECT_URL);
@@ -108,6 +111,7 @@ const DEFAULT_OPTIONS: Omit<ConnectOptions, 'clientId'> = {
   onClose: noop,
   payrollProvider: null,
   products: [],
+  clientName: undefined,
   sandbox: false,
   state: null,
   zIndex: 999,


### PR DESCRIPTION
## What
- Introduces a new optional parameter to `useFinchConnect` to override the displayed application name in Finch connect UI. The provided `clientName` should be a string that has already been pre-approved from Finch.