### PR TITLE
fix: Update session ID query parameter to session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tryfinch/react-connect",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-replace": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Finch SDK for embedding Finch Connect in API React Single Page Applications (SPA)",
   "keywords": [
     "finch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ const constructAuthUrl = (connectOptions: ConnectOptions) => {
 
   if ('sessionId' in connectOptions) {
     const { sessionId, products } = connectOptions;
-    authUrl.searchParams.append('session_id', sessionId);
+    authUrl.searchParams.append('session', sessionId);
     if (products) authUrl.searchParams.append('products', products.join(' '));
   } else {
     const {


### PR DESCRIPTION
## What
Update session ID query parameter to `session`

## Why
Its `session` in Finch Connect not `session_id`