### PR TITLE
feat: Add idpRedirectUri to SuccessEvent and FinchConnectAuthMessage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tryfinch/react-connect",
-      "version": "3.10.0",
+      "version": "3.11.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-replace": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "Finch SDK for embedding Finch Connect in API React Single Page Applications (SPA)",
   "keywords": [
     "finch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ type HasKey<T, K extends PropertyKey> = T extends Record<K, unknown> ? T : never
 export type SuccessEvent = {
   code: string;
   state?: string;
+  idpRedirectUri?: string;
 };
 
 export type ErrorEvent = {
@@ -59,6 +60,7 @@ type FinchConnectAuthMessage = { name: typeof POST_MESSAGE_NAME } & (
       kind: 'success';
       code: string;
       state?: string;
+      idpRedirectUri?: string;
     }
   | {
       kind: 'error';
@@ -233,6 +235,7 @@ export const useFinchConnect = (options: Partial<ConnectOptions>): { open: OpenF
           combinedOptions.onSuccess({
             code: event.data.code,
             state: event.data.state,
+            idpRedirectUri: event.data.idpRedirectUri,
           });
           break;
         default: {


### PR DESCRIPTION
### What
Add `idpRedirectUri` to SuccessEvent and FinchConnectAuthMessage

### Why
To ensure the SDK can get the `idpRedirectUri`