### PR TITLE
feat: Update SDK to enable `employer_connection_error` errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ const App = () => {
   const [code, setCode] = useState(null);
 
   const onSuccess = ({ code }) => setCode(code);
-  const onError = ({ errorMessage }) => console.error(errorMessage);
+  /**
+   * @param {string} errorMessage - The error message
+   * @param {'validation_error' | 'employer_error'} errorType - The type of error
+   * - 'validation_error': Finch Connect failed to open due to validation error
+   * - 'employer_connection_error': The errors employers see within the Finch Connect flow
+   */
+  const onError = ({ errorMessage, errorType }) => console.error(errorMessage, errorType);
   const onClose = () => console.log('User exited Finch Connect');
 
   const { open } = useFinchConnect({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tryfinch/react-connect",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-replace": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "description": "Finch SDK for embedding Finch Connect in API React Single Page Applications (SPA)",
   "keywords": [
     "finch",


### PR DESCRIPTION
## What
Update SDK to enable `employer_connection_error` errors

## Why
This is to enable sending errors employers encounter within Connect to developers