### PR TITLE
fix: Add TS sourceRoot to fix source map sources

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@tryfinch/react-connect",
-      "version": "3.2.0",
+      "version": "3.13.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-replace": "^4.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,17 +4,19 @@ import typescript from '@rollup/plugin-typescript';
 
 import pkg from './package.json';
 
-const plugins = [external(), replace({ SDK_VERSION: pkg.version }), typescript()];
+const plugins = [
+  external(),
+  replace({ SDK_VERSION: pkg.version }),
+  typescript({ sourceRoot: '.' }),
+];
 
 export default [
   {
     input: 'src/index.ts',
-    output: [{ file: pkg.main, format: 'cjs', sourcemap: true }],
-    plugins,
-  },
-  {
-    input: 'src/index.ts',
-    output: [{ file: pkg.module, format: 'es', sourcemap: true }],
+    output: [
+      { file: pkg.main, format: 'cjs', sourcemap: true },
+      { file: pkg.module, format: 'es', sourcemap: true },
+    ],
     plugins,
   },
 ];


### PR DESCRIPTION
## What
Add typescript `sourceRoot` to rollup config to fix source map JS sources

## Why
This is to prevent warnings relating to this package when it's being consumed
![Screenshot 2024-10-29 at 10 06 49 PM](https://github.com/user-attachments/assets/1a778f6f-7e66-4d05-b7e5-cfcba4c17609)
