### PR TITLE
doc(): CONN-2110 update readme to reflect session id preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,12 @@ const App = () => {
   const onClose = () => console.log('User exited Finch Connect');
 
   const { open } = useFinchConnect({
-    clientId: '<your-client-id>',
+    // Session ID is the result from the /connect/sessions API call. See the [doccumentation](https://developer.tryfinch.com/api-reference/connect/new-session#create-a-new-connect-session) about creating new connect sessions for further implementation details.
+    sessionId: '<your-session-id>',
     // The below are only a few of Finch's product scopes, please check Finch's [documentation](https://developer.tryfinch.com/docs/reference/ZG9jOjMxOTg1NTI3-permissions) for the full list
     products: ['company', 'directory'],
-    // Check Finch's [documentation](https://developer.tryfinch.com/docs/reference/96f5be9e0ec1a-providers) for the full list of payroll provider IDs
-    // payrollProvider: '<payroll-provider-id>',
-    // For `sandbox`, omit or use 'false' if in production. Use "finch" or "provider" for sandbox testing, depending on test plan. See Finch's [documentation](https://developer.tryfinch.com/implementation-guide/Test/Testing-Plan) for an overview of Finch and Provider sandboxes.
-    // sandbox: false,
-    // manual: false,
     // zIndex: 999,
+    // state: null,
     onSuccess,
     onError,
     onClose,

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -14,12 +14,10 @@ const App = () => {
   const onClose = () => setResult({ kind: 'closed' });
 
   const { open } = useFinchConnect({
-    clientId: '<your-client-id>',
+    sessionId: '<your-session-id>',
     products: ['company', 'directory', 'individual', 'employment'],
-    // For 'sandbox`, omit or use 'false' if in production. Use "finch" or "provider" for sandbox testing, depending on test plan. See Finch's [documentation](https://developer.tryfinch.com/implementation-guide/Test/Testing-Plan) for an overview of Finch and Provider sandboxes.
-    // sandbox: false,
-    // payrollProvider: '<payroll-provider-id>',
-    //connectionId: '<connection-id>', // Used for reauth of an existing connection
+    // zIndex: 999,
+    // state: null,
     onSuccess,
     onError,
     onClose,


### PR DESCRIPTION
## What
Update the documentation and example to use the session id instead of the legacy flow. Do the same for the example.

## Why
Legacy flow is causing problems for some users with the SDK and the goal is to eventually deprecate so we want to encourage more users to follow the preferred path.

## Tests
N/A - it's docs