### PR TITLE
feat: v4.0.0 - clean up session ID requirement changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# ai
+**/.claude/*.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# v4.0.0
+
+## ⚠️ Breaking Changes
+- A session ID is now required when calling the `open` method to launch Finch Connect. You can create a session using the [Connect session endpoint](https://developer.tryfinch.com/api-reference/connect/new-session) on the Finch API.
+- The `state` parameter has been moved from the `initialize` call to the `open` call
+- The `open` call no longer allows overriding values for the auth session, all values must be set in the session created by calling the API

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ npm install --save @tryfinch/react-connect
 
 ## Usage
 
+See the example app at `example/src` for a functional example
+
 ```jsx
 import React, { useState } from 'react';
 import { useFinchConnect } from '@tryfinch/react-connect';
@@ -17,33 +19,38 @@ import { useFinchConnect } from '@tryfinch/react-connect';
 const App = () => {
   const [code, setCode] = useState(null);
 
-  const onSuccess = ({ code }) => setCode(code);
+  // Define callbacks
+
+  /**
+   * @param {string} code - The authorization code to exchange for an access token
+   * @param {string?} state - The state value that was provided when launching Connect
+   */
+  const onSuccess = ({ code, state }) => setCode(code);
   /**
    * @param {string} errorMessage - The error message
    * @param {'validation_error' | 'employer_error'} errorType - The type of error
-   * - 'validation_error': Finch Connect failed to open due to validation error
-   * - 'employer_connection_error': The errors employers see within the Finch Connect flow
+   *    - 'validation_error': Finch Connect failed to open due to validation error
+   *    - 'employer_connection_error': The errors employers see within the Finch Connect flow
    */
   const onError = ({ errorMessage, errorType }) => console.error(errorMessage, errorType);
   const onClose = () => console.log('User exited Finch Connect');
 
-  // Generate a session ID using the /connect/sessions endpoint on the Finch API
-  // See the docs here https://developer.tryfinch.com/api-reference/connect/new-session#create-a-new-connect-session
-  const sessionId = '';
-
+  // Initialize the FinchConnect hook
   const { open } = useFinchConnect({
-    sessionId,
-    // zIndex: 999, // Set this to change the z-index of the Connect iframe, defaults to 999
     onSuccess,
     onError,
     onClose,
   });
 
+  // Generate a session ID using the /connect/sessions endpoint on the Finch API
+  // See the docs here https://developer.tryfinch.com/api-reference/connect/new-session#create-a-new-connect-session
+  const sessionId = '';
+
   return (
     <div>
       <header>
         <p>Code: {code}</p>
-        <button type="button" onClick={() => open()}>
+        <button type="button" onClick={() => open({ sessionId })}>
           Open Finch Connect
         </button>
       </header>

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -21,11 +21,12 @@
     },
     "..": {
       "name": "@tryfinch/react-connect",
-      "version": "3.14.0",
+      "version": "4.0.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-replace": "^4.0.0",
         "@rollup/plugin-typescript": "^11.1.0",
+        "@types/jest": "^30.0.0",
         "@types/react": "^16.14.40",
         "@typescript-eslint/eslint-plugin": "^5.59.0",
         "@typescript-eslint/parser": "^5.59.0",
@@ -33,9 +34,14 @@
         "eslint-config-airbnb": "^18.2.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-prettier": "^3.1.4",
+        "jest": "^30.0.5",
+        "jest-environment-jsdom": "^30.0.5",
+        "jsdom": "^26.1.0",
         "react": "^16.9.0",
         "rollup": "^2.75.7",
         "rollup-plugin-peer-deps-external": "^2.2.0",
+        "ts-jest": "^29.4.1",
+        "tslib": "^2.8.1",
         "typescript": "^4.9.5"
       },
       "engines": {
@@ -21321,6 +21327,7 @@
       "requires": {
         "@rollup/plugin-replace": "^4.0.0",
         "@rollup/plugin-typescript": "^11.1.0",
+        "@types/jest": "^30.0.0",
         "@types/react": "^16.14.40",
         "@typescript-eslint/eslint-plugin": "^5.59.0",
         "@typescript-eslint/parser": "^5.59.0",
@@ -21328,9 +21335,14 @@
         "eslint-config-airbnb": "^18.2.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-prettier": "^3.1.4",
+        "jest": "^30.0.5",
+        "jest-environment-jsdom": "^30.0.5",
+        "jsdom": "^26.1.0",
         "react": "^16.9.0",
         "rollup": "^2.75.7",
         "rollup-plugin-peer-deps-external": "^2.2.0",
+        "ts-jest": "^29.4.1",
+        "tslib": "^2.8.1",
         "typescript": "^4.9.5"
       },
       "dependencies": {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,36 +6,61 @@ import Result, { ResultContainer } from './Result';
 import './App.css';
 
 const App = () => {
+  const [sessionId, setSessionId] = useState<string>('');
   const [sendState, setSendState] = useState<boolean>(false);
   const [result, setResult] = useState<ResultContainer>();
 
+  // Define callbacks
   const onSuccess = (value: SuccessEvent) => setResult({ kind: 'success', value });
   const onError = (value: ErrorEvent) => setResult({ kind: 'error', value });
   const onClose = () => setResult({ kind: 'closed' });
 
-  const sessionId = '';
-
+  // Initialize the FinchConnect hook
   const { open } = useFinchConnect({
-    sessionId,
     onSuccess,
     onError,
     onClose,
   });
 
-  const submissionHandler: React.FormEventHandler<HTMLFormElement>  = (e) => {
+  // Call the open method when submitting the form
+  const submissionHandler: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
     open({
-      ...(sendState ? { state: new Date().toISOString() } : undefined),
-    })
+      // Generate a session ID using the /connect/sessions endpoint on the Finch API
+      // See the docs here https://developer.tryfinch.com/api-reference/connect/new-session#create-a-new-connect-session
+      sessionId: sessionId.trim(),
+      // An optional state parameter can be passed
+      // https://datatracker.ietf.org/doc/html/rfc6749#section-10.12
+      ...(sendState ? { state: new Date().toISOString() } : {}),
+      // An optional value for the z-index of the Finch Connect iframe
+      // Defaults to 999 if not provided
+      // zIndex: 998,
+    });
   };
 
   return (
     <div className="container">
-      <h2><a href="https://www.npmjs.com/package/@tryfinch/react-connect">@tryfinch/react-connect</a> Example App</h2>
+      <h2>
+        <a href="https://www.npmjs.com/package/@tryfinch/react-connect">@tryfinch/react-connect</a>{' '}
+        Example App
+      </h2>
       <form className="actions" onSubmit={submissionHandler}>
         <div className="row">
+          <label className="top-label">Session UUID:</label>
+          <input
+            type="text"
+            placeholder="Enter session UUID"
+            value={sessionId}
+            onChange={(e) => setSessionId(e.target.value)}
+          />
+        </div>
+        <div className="row">
           <label className="top-label">Include State:</label>
-          <input type="checkbox" checked={sendState} onChange={() => setSendState(prev => !prev)} />
+          <input
+            type="checkbox"
+            checked={sendState}
+            onChange={() => setSendState((prev) => !prev)}
+          />
         </div>
         <div className="row">
           <button className="cta" type="submit">
@@ -44,8 +69,10 @@ const App = () => {
         </div>
       </form>
       <div className="results">
-          { !result && <p>Complete a Finch Connect session and the success event will be displayed here</p> }
-          { result && <Result result={result} /> }
+        {!result && (
+          <p>Complete a Finch Connect session and the success event will be displayed here</p>
+        )}
+        {result && <Result result={result} />}
       </div>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.15.1",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tryfinch/react-connect",
-      "version": "3.15.1",
+      "version": "4.0.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-replace": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryfinch/react-connect",
-  "version": "3.15.1",
+  "version": "4.0.0",
   "description": "Finch SDK for embedding Finch Connect in API React Single Page Applications (SPA)",
   "keywords": [
     "finch",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { constructAuthUrl, validateConnectOptions } from './index';
+import { constructAuthUrl } from './index';
 
 const NOOP_CALLBACKS = {
   onSuccess: jest.fn(),
@@ -9,47 +9,16 @@ const NOOP_CALLBACKS = {
 
 describe('Finch React SDK', () => {
   describe('constructAuthUrl', () => {
-    it('returns the correct auth URL', () => {
-      const authUrl = constructAuthUrl({ sessionId: '123', state: null, ...NOOP_CALLBACKS });
-      expect(authUrl.startsWith('https://connect.tryfinch.com/authorize?')).toBe(true);
-    });
-
-    it('uses the provided connectUrl and redirectUrl if they are provided', () => {
-      const authUrl = constructAuthUrl({
-        sessionId: '123',
-        state: null,
-        apiConfig: {
-          connectUrl: 'https://cool.site',
-          redirectUrl: 'https://cool.site/redirect',
-        },
-        ...NOOP_CALLBACKS,
-      });
-      expect(authUrl.startsWith('https://cool.site/authorize?')).toBe(true);
-      expect(authUrl).toContain('redirect_uri=https%3A%2F%2Fcool.site%2Fredirect');
-    });
-
-    it('adds only the session parameter if the sessionId is provided', () => {
+    it('adds the session parameter', () => {
       const authUrl = constructAuthUrl({
         sessionId: 'test-session-id',
-        state: null,
-        ...NOOP_CALLBACKS,
       });
-
       expect(authUrl).toContain('session=test-session-id');
-      expect(authUrl).not.toContain('client_id=');
-      expect(authUrl).not.toContain('payroll_provider=');
-      expect(authUrl).not.toContain('category=');
-      expect(authUrl).not.toContain('products=');
-      expect(authUrl).not.toContain('manual=');
-      expect(authUrl).not.toContain('sandbox=');
-      expect(authUrl).not.toContain('client_name=');
-      expect(authUrl).not.toContain('connection_id=');
     });
 
     it('adds all the expected base parameters to the auth URL', () => {
       const expectedParameters = {
         app_type: 'spa',
-        redirect_uri: encodeURIComponent('https://tryfinch.com'),
         sdk_host_url: encodeURIComponent('http://localhost'),
         mode: 'employer',
         sdk_version: 'react-SDK_VERSION',
@@ -57,8 +26,6 @@ describe('Finch React SDK', () => {
 
       const authUrl = constructAuthUrl({
         sessionId: 'test-session-id',
-        state: null,
-        ...NOOP_CALLBACKS,
       });
 
       Object.entries(expectedParameters).forEach(([key, value]) => {
@@ -72,13 +39,16 @@ describe('Finch React SDK', () => {
 
       expect(authUrl).toContain('state=test-state');
     });
-  });
 
-  describe('validateConnectOptions', () => {
-    it('throws an error if no sessionId is provided', () => {
-      expect(() => validateConnectOptions({})).toThrow(
-        'must specify a sessionId in options for useFinchConnect'
-      );
+    it('uses the provided connectUrl if provided', () => {
+      const authUrl = constructAuthUrl({
+        sessionId: '123',
+        apiConfig: {
+          connectUrl: 'https://cool.site',
+        },
+        ...NOOP_CALLBACKS,
+      });
+      expect(authUrl.startsWith('https://cool.site/authorize?')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Bumps the major version to v4.0.0 and cleans up the changes that dropped support for static Connect.

The initialize call now takes in the callbacks and optional override for the base URL. The base URL override is not documented as it is an internal feature that customers will not have a use for.

The open call now takes in the session ID and optional state and z-index value.

All values are loaded from the provided session with no ability to override them.

## Testing
- Unit test coverage for critical URL building functionality
- Tested with the Finch Playground to verify things work as expected